### PR TITLE
[APP-8695] Handle errors during provisioning

### DIFF
--- a/lib/src/models/device_online_state.dart
+++ b/lib/src/models/device_online_state.dart
@@ -4,4 +4,5 @@ enum DeviceOnlineState {
   checking,
   agentConnected,
   success,
+  errorConnecting,
 }

--- a/lib/src/view/check_connected_device_online_screen.dart
+++ b/lib/src/view/check_connected_device_online_screen.dart
@@ -104,6 +104,13 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
     );
   }
 
+  Widget _buildErrorConnectingState(BuildContext context) {
+    // TODO: button and "X" icon, goes back to network selection
+    return Center(
+      child: Text('Error connecting to device'),
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return Consumer<CheckConnectedDeviceOnlineScreenViewModel>(
@@ -114,6 +121,7 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
             DeviceOnlineState.checking => _buildCheckingState(context),
             DeviceOnlineState.agentConnected => _buildAgentConnectedState(context),
             DeviceOnlineState.success => _buildSuccessState(context),
+            DeviceOnlineState.errorConnecting => _buildErrorConnectingState(context),
           },
         );
       },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,10 @@ dependencies:
   permission_handler: ^12.0.0+1
   viam_sdk: ^0.6.4
   collection: ^1.18.0
-  viam_flutter_provisioning: ^0.0.9
+  viam_flutter_provisioning:
+    git:
+      url: https://github.com/viamrobotics/viam_flutter_provisioning.git
+      ref: kevin/read-errors-change
   flutter_platform_widgets: ^8.0.0
   provider: ^6.1.5
   


### PR DESCRIPTION
https://viam.atlassian.net/browse/APP-8695

Doing what we can't do with hotspot. Reading errors while we're checking for the machine to come online

![Screenshot 2025-06-30 at 4 17 07 PM](https://github.com/user-attachments/assets/8b31e5bf-13db-484a-a5e3-cb98854de2f3)

The last error in the list is the current one, and the errors get appended as you go. Avoiding hardcoding checking for certain specific error strings. Knowing a new error appeared after trying to setmachinecreds/setnetworkcreds is probably good enough