### PR TITLE
[APP-8724] Disallow reconnect non-existing machine 

### DIFF
--- a/example/lib/provision_new_machine_screen.dart
+++ b/example/lib/provision_new_machine_screen.dart
@@ -61,6 +61,8 @@ class _ProvisionNewRobotScreenState extends State<ProvisionNewRobotScreen> {
           Navigator.of(context).pop();
         }, existingMachineExit: () {
           Navigator.of(context).pop();
+        }, nonexistentMachineExit: () {
+          Navigator.of(context).pop();
         }),
       ),
     ));

--- a/example/lib/reconnect_machines_screen.dart
+++ b/example/lib/reconnect_machines_screen.dart
@@ -116,6 +116,8 @@ class _ReconnectRobotsScreenState extends State<ReconnectRobotsScreen> {
             Navigator.of(context).pop();
           }, existingMachineExit: () {
             Navigator.of(context).pop();
+          }, nonexistentMachineExit: () {
+            Navigator.of(context).pop();
           }),
         ),
       ));


### PR DESCRIPTION
https://viam.atlassian.net/browse/APP-8724

Depends/based on branch in #17.

![reconnect](https://github.com/user-attachments/assets/6b6eb4d4-5a09-41e1-92ed-44d131afe009)

Disallows "reconnecting" a machine that does not exist. We may be able to go one step further (in the package, in apps, with a combination of changes) that only allow reconnecting if the machine matches the `Robot` they setup.