### PR TITLE
Separate callback for agent configured

### DIFF
--- a/example/lib/provision_new_machine_screen.dart
+++ b/example/lib/provision_new_machine_screen.dart
@@ -64,6 +64,8 @@ class _ProvisionNewRobotScreenState extends State<ProvisionNewRobotScreen> {
         ),
         builder: (context, child) => BluetoothProvisioningFlow(onSuccess: () {
           Navigator.of(context).pop();
+        }, handleAgentConfigured: () {
+          Navigator.of(context).pop();
         }, existingMachineExit: () {
           Navigator.of(context).pop();
         }, nonexistentMachineExit: () {

--- a/example/lib/reconnect_machines_screen.dart
+++ b/example/lib/reconnect_machines_screen.dart
@@ -114,6 +114,8 @@ class _ReconnectRobotsScreenState extends State<ReconnectRobotsScreen> {
           ),
           builder: (context, child) => BluetoothProvisioningFlow(onSuccess: () {
             Navigator.of(context).pop();
+          }, handleAgentConfigured: () {
+            Navigator.of(context).pop();
           }, existingMachineExit: () {
             Navigator.of(context).pop();
           }, nonexistentMachineExit: () {

--- a/lib/src/flow/bluetooth_provisioning_flow.dart
+++ b/lib/src/flow/bluetooth_provisioning_flow.dart
@@ -4,11 +4,17 @@ class BluetoothProvisioningFlow extends StatefulWidget {
   const BluetoothProvisioningFlow({
     super.key,
     required this.onSuccess,
+    required this.handleAgentConfigured,
     required this.existingMachineExit,
     required this.nonexistentMachineExit,
   });
 
   final VoidCallback onSuccess;
+
+  /// agent has indicated the machine is online and has machine credentials
+  /// though it's still not online in app.viam.com
+  final VoidCallback handleAgentConfigured;
+
   final VoidCallback existingMachineExit;
   final VoidCallback nonexistentMachineExit;
 
@@ -165,6 +171,7 @@ class _BluetoothProvisioningFlowState extends State<BluetoothProvisioningFlow> {
                         ChangeNotifierProvider.value(
                           value: CheckConnectedDeviceOnlineScreenViewModel(
                             handleSuccess: widget.onSuccess,
+                            handleAgentConfigured: widget.handleAgentConfigured,
                             handleError: () {
                               _onPreviousPage(); // back to network selection
                             },

--- a/lib/src/flow/bluetooth_provisioning_flow.dart
+++ b/lib/src/flow/bluetooth_provisioning_flow.dart
@@ -12,7 +12,7 @@ class BluetoothProvisioningFlow extends StatefulWidget {
   final VoidCallback onSuccess;
 
   /// agent has indicated the machine is online and has machine credentials
-  /// though it's still not online in app.viam.com
+  /// though it may not be online in app.viam.com yet
   final VoidCallback handleAgentConfigured;
 
   final VoidCallback existingMachineExit;

--- a/lib/src/view/check_connected_device_online_screen.dart
+++ b/lib/src/view/check_connected_device_online_screen.dart
@@ -43,7 +43,6 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
   }
 
   Widget _buildAgentConnectedState(BuildContext context) {
-    // Currently same as checking, can customize later if needed
     final viewModel = Provider.of<CheckConnectedDeviceOnlineScreenViewModel>(context);
     return Center(
       child: Column(
@@ -64,7 +63,7 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
           ),
           Spacer(),
           FilledButton(
-            onPressed: viewModel.handleSuccess,
+            onPressed: viewModel.handleAgentConfigured,
             child: Text('Close'),
           ),
           SizedBox(height: 16),
@@ -73,7 +72,6 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
     );
   }
 
-  // Helper method for the 'success' state
   Widget _buildSuccessState(BuildContext context) {
     final viewModel = Provider.of<CheckConnectedDeviceOnlineScreenViewModel>(context);
     return Padding(

--- a/lib/src/view_models/check_connected_device_online_screen_view_model.dart
+++ b/lib/src/view_models/check_connected_device_online_screen_view_model.dart
@@ -4,9 +4,9 @@ class CheckConnectedDeviceOnlineScreenViewModel extends ChangeNotifier {
   final VoidCallback handleSuccess;
 
   /// agent has indicated the machine is online and has machine credentials
-  /// though it's still not online in app.viam.com
-  final VoidCallback handleAgentConfigured
-  
+  /// though it may not be online in app.viam.com yet
+  final VoidCallback handleAgentConfigured;
+
   final VoidCallback handleError;
   final Robot robot;
   String? get errorMessage => _checkingDeviceOnlineRepository.errorMessage;

--- a/lib/src/view_models/check_connected_device_online_screen_view_model.dart
+++ b/lib/src/view_models/check_connected_device_online_screen_view_model.dart
@@ -2,6 +2,11 @@ part of '../../viam_flutter_bluetooth_provisioning_widget.dart';
 
 class CheckConnectedDeviceOnlineScreenViewModel extends ChangeNotifier {
   final VoidCallback handleSuccess;
+
+  /// agent has indicated the machine is online and has machine credentials
+  /// though it's still not online in app.viam.com
+  final VoidCallback handleAgentConfigured
+  
   final VoidCallback handleError;
   final Robot robot;
   String? get errorMessage => _checkingDeviceOnlineRepository.errorMessage;
@@ -20,6 +25,7 @@ class CheckConnectedDeviceOnlineScreenViewModel extends ChangeNotifier {
 
   CheckConnectedDeviceOnlineScreenViewModel({
     required this.handleSuccess,
+    required this.handleAgentConfigured,
     required this.handleError,
     required this.robot,
     required CheckingDeviceOnlineRepository checkingDeviceOnlineRepository,


### PR DESCRIPTION
Right now this has the same callback as success, though apps will want to do their own thing if this happens vs coming online in app.viam (shouldn't navigate to machine page for example, because can't connect yet). 