### PR TITLE
[CONSULT-1200] Add fragment id update logic in widget

### DIFF
--- a/example/lib/provision_new_machine_screen.dart
+++ b/example/lib/provision_new_machine_screen.dart
@@ -61,6 +61,7 @@ class _ProvisionNewRobotScreenState extends State<ProvisionNewRobotScreen> {
           isNewMachine: true,
           mainRobotPart: mainPart,
           psk: Consts.psk,
+          fragmentId: null,
           connectBluetoothDeviceRepository: ConnectBluetoothDeviceRepository(),
         ),
         builder: (context, child) => BluetoothProvisioningFlow(onSuccess: () {

--- a/example/lib/reconnect_machines_screen.dart
+++ b/example/lib/reconnect_machines_screen.dart
@@ -111,6 +111,7 @@ class _ReconnectRobotsScreenState extends State<ReconnectRobotsScreen> {
             isNewMachine: false,
             mainRobotPart: mainPart,
             psk: Consts.psk,
+            fragmentId: null,
             connectBluetoothDeviceRepository: ConnectBluetoothDeviceRepository(),
           ),
           builder: (context, child) => BluetoothProvisioningFlow(onSuccess: () {

--- a/lib/src/view_models/bluetooth_provisioning_flow_view_model.dart
+++ b/lib/src/view_models/bluetooth_provisioning_flow_view_model.dart
@@ -8,6 +8,7 @@ class BluetoothProvisioningFlowViewModel extends ChangeNotifier {
     required this.connectBluetoothDeviceRepository,
     required mainRobotPart,
     required String psk,
+    required this.fragmentId,
   })  : _mainRobotPart = mainRobotPart,
         _psk = psk;
   final Viam viam;
@@ -15,16 +16,22 @@ class BluetoothProvisioningFlowViewModel extends ChangeNotifier {
   final bool isNewMachine;
   final ConnectBluetoothDeviceRepository connectBluetoothDeviceRepository;
 
+  /// if not specified, the fragmentId read from the connected device will be used instead
+  final String? fragmentId;
+
   final RobotPart _mainRobotPart;
   final String _psk;
   BluetoothDevice? get device => connectBluetoothDeviceRepository.device;
 
   Future<void> writeConfig({required String ssid, required String? password}) async {
     await connectBluetoothDeviceRepository.writeConfig(
+      viam: viam,
+      robot: robot,
       ssid: ssid,
       password: password,
       mainRobotPart: _mainRobotPart,
       psk: _psk,
+      fragmentId: fragmentId,
     );
   }
 }


### PR DESCRIPTION
https://viam.atlassian.net/browse/CONSULT-1200

This came from trying to add to a client app and thinking about the logic for doing fragment overrides / updating the machine config w/ a fragmentId (however you want to call it)

Spoke w/ @clintpurser and was suggested that we could add this to the package (with an optional parameter you can pass in to use). If the parameter isn't passed in, we'll try to read the fragmentId from the connected device.

<img width="759" alt="Screenshot 2025-07-09 at 2 08 12 PM" src="https://github.com/user-attachments/assets/b4edf1bf-15f4-45f4-bdbc-4983861bd232" />
