### PR TITLE
CONSULT-1355 Configurable copy for intro screen two

### DIFF
--- a/lib/src/flow/bluetooth_provisioning_flow.dart
+++ b/lib/src/flow/bluetooth_provisioning_flow.dart
@@ -217,7 +217,13 @@ class _BluetoothProvisioningFlowState extends State<BluetoothProvisioningFlow> {
                         subtitle: viewModel.copy.introScreenSubtitle,
                         ctaText: viewModel.copy.introScreenCtaText,
                       ),
-                      IntroScreenTwo(handleNextTapped: _onNextPage),
+                      IntroScreenTwo(
+                        handleNextTapped: _onNextPage,
+                        turnOnTitle: viewModel.copy.introScreenTwoTurnOnTitle,
+                        turnOnSubtitle: viewModel.copy.introScreenTwoTurnOnSubtitle,
+                        bluetoothTitle: viewModel.copy.introScreenTwoBluetoothTitle,
+                        bluetoothSubtitle: viewModel.copy.introScreenTwoBluetoothSubtitle,
+                      ),
                       ChangeNotifierProvider.value(
                         value: BluetoothScanningScreenViewModel(
                           onDeviceSelected: _onDeviceConnected,

--- a/lib/src/models/bluetooth_provisioning_flow_copy.dart
+++ b/lib/src/models/bluetooth_provisioning_flow_copy.dart
@@ -6,6 +6,12 @@ class BluetoothProvisioningFlowCopy {
     this.introScreenTitle = 'Connect your device',
     this.introScreenSubtitle = 'We\'ll walk you through a short setup process to get your device up and running.',
     this.introScreenCtaText = 'Get started',
+    // Intro screen tow
+    this.introScreenTwoTurnOnTitle = 'Turn on your VC Box',
+    this.introScreenTwoTurnOnSubtitle = 'Plug in the VC Box and power it on. The light should be slowly flashing blue.',
+    this.introScreenTwoBluetoothTitle = 'Pair via Bluetooth',
+    // TODO: add markdown package so we can have italicized text
+    this.introScreenTwoBluetoothSubtitle = 'Open your phone’s settings app and go to Settings > Bluetooth. Make sure it is set to “ON.”',
     // Bluetooth scanning
     this.bluetoothScanningTitle = 'Select your Device',
     this.bluetoothScanningScanCtaText = 'Scan network again',
@@ -44,6 +50,12 @@ class BluetoothProvisioningFlowCopy {
   final String introScreenTitle;
   final String introScreenSubtitle;
   final String introScreenCtaText;
+
+  // Intro screen two
+  final String introScreenTwoTurnOnTitle;
+  final String introScreenTwoTurnOnSubtitle;
+  final String introScreenTwoBluetoothTitle;
+  final String introScreenTwoBluetoothSubtitle;
 
   // Bluetooth scanning screen
   final String bluetoothScanningTitle;

--- a/lib/src/view/intro_screen_one.dart
+++ b/lib/src/view/intro_screen_one.dart
@@ -23,7 +23,7 @@ class IntroScreenOne extends StatelessWidget {
         crossAxisAlignment: CrossAxisAlignment.stretch,
         children: [
           const Spacer(),
-          Icon(Icons.tap_and_play, size: 64),
+          Icon(Icons.tap_and_play, size: 64, color: const Color(0xFF9C9CA4)),
           const SizedBox(height: 24),
           Text(
             title,

--- a/lib/src/view/intro_screen_two.dart
+++ b/lib/src/view/intro_screen_two.dart
@@ -2,8 +2,19 @@ part of '../../viam_flutter_bluetooth_provisioning_widget.dart';
 
 class IntroScreenTwo extends StatelessWidget {
   final VoidCallback handleNextTapped;
+  final String turnOnTitle;
+  final String turnOnSubtitle;
+  final String bluetoothTitle;
+  final String bluetoothSubtitle;
 
-  const IntroScreenTwo({super.key, required this.handleNextTapped});
+  const IntroScreenTwo({
+    super.key,
+    required this.handleNextTapped,
+    required this.turnOnTitle,
+    required this.turnOnSubtitle,
+    required this.bluetoothTitle,
+    required this.bluetoothSubtitle,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -14,62 +25,42 @@ class IntroScreenTwo extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
-            Spacer(),
+            const Spacer(),
+            Icon(Icons.power_settings_new, size: 40, color: const Color(0xFF9C9CA4)),
+            const SizedBox(height: 24),
             Text(
-              'Make sure that...',
+              turnOnTitle,
               textAlign: TextAlign.center,
               style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
             ),
-            SizedBox(height: 40),
-            Icon(Icons.power_settings_new, size: 32),
-            SizedBox(height: 16),
+            const SizedBox(height: 16),
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 64),
-              child: RichText(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Text(
+                turnOnSubtitle,
                 textAlign: TextAlign.center,
-                text: TextSpan(
-                  style: Theme.of(context).textTheme.bodyLarge,
-                  children: [
-                    TextSpan(text: 'Your device is '),
-                    TextSpan(
-                      text: 'plugged in ',
-                      style: const TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                    TextSpan(text: 'and '),
-                    TextSpan(
-                      text: 'powered on',
-                      style: const TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                  ],
-                ),
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: Colors.grey.shade600),
               ),
             ),
-            SizedBox(height: 40),
-            Icon(Icons.bluetooth, size: 32),
-            SizedBox(height: 16),
+            const SizedBox(height: 64),
+            Icon(Icons.bluetooth, size: 40, color: const Color(0xFF9C9CA4)),
+            SizedBox(height: 24),
+            Text(
+              bluetoothTitle,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 16),
             Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 64),
-              child: RichText(
+              padding: const EdgeInsets.symmetric(horizontal: 24),
+              child: Text(
+                bluetoothSubtitle,
                 textAlign: TextAlign.center,
-                text: TextSpan(
-                  style: Theme.of(context).textTheme.bodyLarge,
-                  children: [
-                    TextSpan(
-                      text: 'Bluetooth ',
-                      style: const TextStyle(fontWeight: FontWeight.bold),
-                    ),
-                    TextSpan(text: 'is enabled on your phone. You can do this in '),
-                    TextSpan(
-                      text: 'Settings > Bluetooth',
-                      style: const TextStyle(fontStyle: FontStyle.italic),
-                    ),
-                    TextSpan(text: '.'),
-                  ],
-                ),
+                style: Theme.of(context).textTheme.bodyLarge?.copyWith(color: Colors.grey.shade600),
               ),
             ),
-            SizedBox(height: 40),
-            Spacer(),
+            const Spacer(),
+            const Spacer(),
             FilledButton(
               onPressed: handleNextTapped,
               child: Text('Next'),


### PR DESCRIPTION
Changing designs a bit to match latest I'm seeing + (more important part) make it configurable for clients. 

Left a TODO: if we want to pass in markdown which is in the non-custom designs - and probably the best way to rather than doing it with `TextSpan`

<img width="400" height="866" alt="IMG_0377" src="https://github.com/user-attachments/assets/7272719a-b71f-4122-9264-ecc341a82ef7" />

[Internal Figma](https://www.figma.com/design/mP2OO94hJGYpP8bFUPMX0f/Widget-Library?node-id=6729-3704&t=faaJdURjRjrdgr4K-1)