### PR TITLE
APP-8935 Checking online listenablebuilder + view model property

### DIFF
--- a/lib/src/flow/bluetooth_provisioning_flow.dart
+++ b/lib/src/flow/bluetooth_provisioning_flow.dart
@@ -276,8 +276,12 @@ class _BluetoothProvisioningFlowState extends State<BluetoothProvisioningFlow> {
                         child: ConnectedBluetoothDeviceScreen(),
                       ),
                       if (widget.viewModel.device != null)
-                        ChangeNotifierProvider.value(
-                          value: CheckConnectedDeviceOnlineScreenViewModel(
+                        CheckConnectedDeviceOnlineScreen(
+                          viewModel: CheckConnectedDeviceOnlineScreenViewModel(
+                            robot: widget.viewModel.robot,
+                            successTitle: widget.viewModel.copy.checkingOnlineSuccessTitle,
+                            successSubtitle: widget.viewModel.copy.checkingOnlineSuccessSubtitle,
+                            successCta: widget.viewModel.copy.checkingOnlineSuccessCta,
                             handleSuccess: widget.onSuccess,
                             handleAgentConfigured: widget.handleAgentConfigured,
                             handleError: _onPreviousPage, // back to network selection
@@ -286,12 +290,6 @@ class _BluetoothProvisioningFlowState extends State<BluetoothProvisioningFlow> {
                               viam: widget.viewModel.viam,
                               robot: widget.viewModel.robot,
                             ),
-                            robot: widget.viewModel.robot,
-                          ),
-                          child: CheckConnectedDeviceOnlineScreen(
-                            successTitle: widget.viewModel.copy.checkingOnlineSuccessTitle,
-                            successSubtitle: widget.viewModel.copy.checkingOnlineSuccessSubtitle,
-                            successCta: widget.viewModel.copy.checkingOnlineSuccessCta,
                           ),
                         ),
                     ],

--- a/lib/src/view/check_connected_device_online_screen.dart
+++ b/lib/src/view/check_connected_device_online_screen.dart
@@ -1,16 +1,9 @@
 part of '../../viam_flutter_bluetooth_provisioning_widget.dart';
 
 class CheckConnectedDeviceOnlineScreen extends StatefulWidget {
-  const CheckConnectedDeviceOnlineScreen({
-    super.key,
-    required this.successTitle,
-    required this.successSubtitle,
-    required this.successCta,
-  });
+  const CheckConnectedDeviceOnlineScreen({super.key, required this.viewModel});
 
-  final String successTitle;
-  final String successSubtitle;
-  final String successCta;
+  final CheckConnectedDeviceOnlineScreenViewModel viewModel;
 
   @override
   State<CheckConnectedDeviceOnlineScreen> createState() => _CheckConnectedDeviceOnlineScreenState();
@@ -20,9 +13,7 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      context.read<CheckConnectedDeviceOnlineScreenViewModel>().startChecking();
-    });
+    widget.viewModel.startChecking();
   }
 
   Widget _buildCheckingState(BuildContext context) {
@@ -52,7 +43,6 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
   }
 
   Widget _buildAgentConnectedState(BuildContext context) {
-    final viewModel = Provider.of<CheckConnectedDeviceOnlineScreenViewModel>(context);
     return Center(
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
@@ -65,14 +55,14 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
           ),
           SizedBox(height: 8),
           Text(
-            '${viewModel.robot.name} is connected and almost ready to use. You can leave this screen now and it will automatically come online in a few minutes.',
+            '${widget.viewModel.robot.name} is connected and almost ready to use. You can leave this screen now and it will automatically come online in a few minutes.',
             style: Theme.of(context).textTheme.bodyLarge,
             textAlign: TextAlign.center,
             maxLines: null,
           ),
           Spacer(),
           FilledButton(
-            onPressed: viewModel.handleAgentConfigured,
+            onPressed: widget.viewModel.handleAgentConfigured,
             child: Text('Close'),
           ),
           SizedBox(height: 16),
@@ -82,7 +72,6 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
   }
 
   Widget _buildSuccessState(BuildContext context) {
-    final viewModel = Provider.of<CheckConnectedDeviceOnlineScreenViewModel>(context);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0),
       child: Column(
@@ -92,18 +81,18 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
           Spacer(),
           Icon(Icons.check_circle, color: Colors.green, size: 40),
           SizedBox(height: 24),
-          Text(widget.successTitle, style: Theme.of(context).textTheme.titleLarge, textAlign: TextAlign.center),
+          Text(widget.viewModel.successTitle, style: Theme.of(context).textTheme.titleLarge, textAlign: TextAlign.center),
           SizedBox(height: 8),
           Text(
-            widget.successSubtitle,
+            widget.viewModel.successSubtitle,
             style: Theme.of(context).textTheme.bodyLarge,
             textAlign: TextAlign.center,
             maxLines: null,
           ),
           Spacer(),
           FilledButton(
-            onPressed: viewModel.handleSuccess,
-            child: Text(widget.successCta),
+            onPressed: widget.viewModel.handleSuccess,
+            child: Text(widget.viewModel.successCta),
           ),
           SizedBox(height: 16),
         ],
@@ -112,7 +101,6 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
   }
 
   Widget _buildErrorConnectingState(BuildContext context) {
-    final viewModel = Provider.of<CheckConnectedDeviceOnlineScreenViewModel>(context);
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0),
       child: Column(
@@ -125,14 +113,14 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
           Text('Error during setup', style: Theme.of(context).textTheme.titleLarge, textAlign: TextAlign.center),
           SizedBox(height: 8),
           Text(
-            viewModel.errorMessage ?? 'There was an error getting your machine online. Please try again.',
+            widget.viewModel.errorMessage ?? 'There was an error getting your machine online. Please try again.',
             style: Theme.of(context).textTheme.bodyLarge,
             textAlign: TextAlign.center,
             maxLines: 2,
           ),
           Spacer(),
           FilledButton(
-            onPressed: viewModel.handleError,
+            onPressed: widget.viewModel.handleError,
             child: Text('Try again'),
           ),
           SizedBox(height: 16),
@@ -143,11 +131,12 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<CheckConnectedDeviceOnlineScreenViewModel>(
-      builder: (context, viewModel, child) {
+    return ListenableBuilder(
+      listenable: widget.viewModel,
+      builder: (context, child) {
         return Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0),
-          child: switch (viewModel.deviceOnlineState) {
+          child: switch (widget.viewModel.deviceOnlineState) {
             DeviceOnlineState.checking => _buildCheckingState(context),
             DeviceOnlineState.agentConnected => _buildAgentConnectedState(context),
             DeviceOnlineState.success => _buildSuccessState(context),

--- a/lib/src/view_models/check_connected_device_online_screen_view_model.dart
+++ b/lib/src/view_models/check_connected_device_online_screen_view_model.dart
@@ -9,6 +9,9 @@ class CheckConnectedDeviceOnlineScreenViewModel extends ChangeNotifier {
 
   final VoidCallback handleError;
   final Robot robot;
+  final String successTitle;
+  final String successSubtitle;
+  final String successCta;
   String? get errorMessage => _checkingDeviceOnlineRepository.errorMessage;
 
   DeviceOnlineState get deviceOnlineState => _deviceOnlineState;
@@ -27,6 +30,9 @@ class CheckConnectedDeviceOnlineScreenViewModel extends ChangeNotifier {
     required this.handleSuccess,
     required this.handleAgentConfigured,
     required this.handleError,
+    required this.successTitle,
+    required this.successSubtitle,
+    required this.successCta,
     required this.robot,
     required CheckingDeviceOnlineRepository checkingDeviceOnlineRepository,
   })  : _checkingDeviceOnlineRepository = checkingDeviceOnlineRepository,


### PR DESCRIPTION
This actually ends up clearing up an exception I've been seeing too:
```
══╡ EXCEPTION CAUGHT BY SCHEDULER LIBRARY ╞═════════════════════════════════════════════════════════
The following assertion was thrown during a scheduler callback:
This widget has been unmounted, so the State no longer has a context (and should be considered
defunct).
Consider canceling any active work during "dispose" or using the "mounted" getter to determine if
the State is still active.

When the exception was thrown, this was the stack:
#0      State.context.<anonymous closure> (package:flutter/src/widgets/framework.dart:954:9)
#1      State.context (package:flutter/src/widgets/framework.dart:960:6)
#2      _CheckConnectedDeviceOnlineScreenState.initState.<anonymous closure>
(package:viam_flutter_bluetooth_provisioning_widget/src/view/check_connected_device_online_screen.dart:24:7)
#3      SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1442:15)
#4      SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1369:11)
#5      SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:1208:5)
#6      _invoke (dart:ui/hooks.dart:316:13)
#7      PlatformDispatcher._drawFrame (dart:ui/platform_dispatcher.dart:428:5)
#8      _drawFrame (dart:ui/hooks.dart:288:31)
════════════════════════════════════════════════════════════════════════════════════════════════════
```