### PR TITLE
View model: moving more logic into view model + loading logic

### DIFF
--- a/lib/src/flow/bluetooth_provisioning_flow.dart
+++ b/lib/src/flow/bluetooth_provisioning_flow.dart
@@ -43,7 +43,6 @@ class BluetoothProvisioningFlow extends StatefulWidget {
 
 class _BluetoothProvisioningFlowState extends State<BluetoothProvisioningFlow> {
   final PageController _pageController = PageController();
-  bool _isLoading = false;
 
   @override
   void dispose() {
@@ -69,21 +68,9 @@ class _BluetoothProvisioningFlowState extends State<BluetoothProvisioningFlow> {
     }
   }
 
-  void _onWifiCredentials(String ssid, String? psk) async {
-    try {
-      setState(() {
-        _isLoading = true;
-      });
-      await widget.viewModel.writeConfig(ssid: ssid, password: psk);
+  Future<void> _onWifiCredentials(String ssid, String? password) async {
+    if (await widget.viewModel.onWifiCredentials(context, ssid, password)) {
       _onNextPage();
-    } catch (e) {
-      if (mounted) {
-        _showErrorDialog(context, title: 'Failed to write config', error: e.toString());
-      }
-    } finally {
-      setState(() {
-        _isLoading = false;
-      });
     }
   }
 
@@ -103,7 +90,7 @@ class _BluetoothProvisioningFlowState extends State<BluetoothProvisioningFlow> {
             child: Stack(
               children: [
                 Opacity(
-                  opacity: _isLoading ? 0.0 : 1.0,
+                  opacity: widget.viewModel.isLoading ? 0.0 : 1.0,
                   child: PageView(
                     controller: _pageController,
                     physics: NeverScrollableScrollPhysics(),
@@ -167,7 +154,7 @@ class _BluetoothProvisioningFlowState extends State<BluetoothProvisioningFlow> {
                     ],
                   ),
                 ),
-                if (_isLoading) const Center(child: CircularProgressIndicator()),
+                if (widget.viewModel.isLoading) const Center(child: CircularProgressIndicator()),
               ],
             ),
           ),

--- a/lib/src/flow/bluetooth_tethering_flow.dart
+++ b/lib/src/flow/bluetooth_tethering_flow.dart
@@ -43,7 +43,6 @@ class BluetoothTetheringFlow extends StatefulWidget {
 
 class _BluetoothTetheringFlowState extends State<BluetoothTetheringFlow> {
   final PageController _pageController = PageController();
-  bool _isLoading = false;
 
   /// can be flipped on/off by the user depending on how they answer the internet question
   bool _useInternetFlow = false;
@@ -72,21 +71,9 @@ class _BluetoothTetheringFlowState extends State<BluetoothTetheringFlow> {
     }
   }
 
-  void _onWifiCredentials(String ssid, String? psk) async {
-    try {
-      setState(() {
-        _isLoading = true;
-      });
-      await widget.viewModel.writeConfig(ssid: ssid, password: psk);
+  Future<void> _onWifiCredentials(String ssid, String? password) async {
+    if (await widget.viewModel.onWifiCredentials(context, ssid, password)) {
       _onNextPage();
-    } catch (e) {
-      if (mounted) {
-        _showErrorDialog(context, title: 'Failed to write config', error: e.toString());
-      }
-    } finally {
-      setState(() {
-        _isLoading = false;
-      });
     }
   }
 
@@ -136,7 +123,7 @@ class _BluetoothTetheringFlowState extends State<BluetoothTetheringFlow> {
             child: Stack(
               children: [
                 Opacity(
-                  opacity: _isLoading ? 0.0 : 1.0,
+                  opacity: widget.viewModel.isLoading ? 0.0 : 1.0,
                   child: PageView(
                     controller: _pageController,
                     physics: NeverScrollableScrollPhysics(),
@@ -217,7 +204,7 @@ class _BluetoothTetheringFlowState extends State<BluetoothTetheringFlow> {
                     ],
                   ),
                 ),
-                if (_isLoading) const Center(child: CircularProgressIndicator()),
+                if (widget.viewModel.isLoading) const Center(child: CircularProgressIndicator()),
               ],
             ),
           ),


### PR DESCRIPTION
Changes:
* move onwificreds to the view model, can share that between normal flow and tethering now
* move `isLoading` to viewmodel which helps us to show loading when we do some of the status checks that can early exit rather than the screen sitting unmoving