### PR TITLE
Remove checking agent online / agent configured callback

### DIFF
--- a/example/lib/provision_new_machine_screen.dart
+++ b/example/lib/provision_new_machine_screen.dart
@@ -74,9 +74,6 @@ class _ProvisionNewRobotScreenState extends State<ProvisionNewRobotScreen> {
         onSuccess: () {
           Navigator.of(context).pop();
         },
-        handleAgentConfigured: () {
-          Navigator.of(context).pop();
-        },
         existingMachineExit: () {
           Navigator.of(context).pop();
         },
@@ -104,9 +101,6 @@ class _ProvisionNewRobotScreenState extends State<ProvisionNewRobotScreen> {
           checkingOnlineSuccessSubtitle: '${robot.name} is connected and ready to use.',
         ),
         onSuccess: () {
-          Navigator.of(context).pop();
-        },
-        handleAgentConfigured: () {
           Navigator.of(context).pop();
         },
         existingMachineExit: () {

--- a/example/lib/reconnect_machines_screen.dart
+++ b/example/lib/reconnect_machines_screen.dart
@@ -117,9 +117,6 @@ class _ReconnectRobotsScreenState extends State<ReconnectRobotsScreen> {
           onSuccess: () {
             Navigator.of(context).pop();
           },
-          handleAgentConfigured: () {
-            Navigator.of(context).pop();
-          },
           existingMachineExit: () {
             Navigator.of(context).pop();
           },

--- a/lib/src/flow/bluetooth_provisioning_flow.dart
+++ b/lib/src/flow/bluetooth_provisioning_flow.dart
@@ -12,7 +12,6 @@ class BluetoothProvisioningFlow extends StatefulWidget {
     required String agentMinimumVersion,
     required BluetoothProvisioningFlowCopy copy,
     required onSuccess,
-    required handleAgentConfigured,
     required existingMachineExit,
     required nonexistentMachineExit,
     required agentMinimumVersionExit,
@@ -28,7 +27,6 @@ class BluetoothProvisioningFlow extends StatefulWidget {
       agentMinimumVersion: agentMinimumVersion,
       copy: copy,
       onSuccess: onSuccess,
-      handleAgentConfigured: handleAgentConfigured,
       existingMachineExit: existingMachineExit,
       nonexistentMachineExit: nonexistentMachineExit,
       agentMinimumVersionExit: agentMinimumVersionExit,
@@ -142,7 +140,6 @@ class _BluetoothProvisioningFlowState extends State<BluetoothProvisioningFlow> {
                             successSubtitle: widget.viewModel.copy.checkingOnlineSuccessSubtitle,
                             successCta: widget.viewModel.copy.checkingOnlineSuccessCta,
                             handleSuccess: widget.viewModel.onSuccess,
-                            handleAgentConfigured: widget.viewModel.handleAgentConfigured,
                             handleError: _onPreviousPage, // back to network selection
                             checkingDeviceOnlineRepository: CheckingDeviceOnlineRepository(
                               device: widget.viewModel.device!,

--- a/lib/src/flow/bluetooth_provisioning_flow.dart
+++ b/lib/src/flow/bluetooth_provisioning_flow.dart
@@ -146,6 +146,7 @@ class _BluetoothProvisioningFlowState extends State<BluetoothProvisioningFlow> {
                               viam: widget.viewModel.viam,
                               robot: widget.viewModel.robot,
                             ),
+                            connectBluetoothDeviceRepository: widget.viewModel.connectBluetoothDeviceRepository,
                           ),
                         ),
                     ],

--- a/lib/src/flow/bluetooth_provisioning_flow.dart
+++ b/lib/src/flow/bluetooth_provisioning_flow.dart
@@ -146,7 +146,6 @@ class _BluetoothProvisioningFlowState extends State<BluetoothProvisioningFlow> {
                               viam: widget.viewModel.viam,
                               robot: widget.viewModel.robot,
                             ),
-                            connectBluetoothDeviceRepository: widget.viewModel.connectBluetoothDeviceRepository,
                           ),
                         ),
                     ],

--- a/lib/src/flow/bluetooth_tethering_flow.dart
+++ b/lib/src/flow/bluetooth_tethering_flow.dart
@@ -191,6 +191,7 @@ class _BluetoothTetheringFlowState extends State<BluetoothTetheringFlow> {
                               viam: widget.viewModel.viam,
                               robot: widget.viewModel.robot,
                             ),
+                            connectBluetoothDeviceRepository: widget.viewModel.connectBluetoothDeviceRepository,
                           ),
                         ),
                     ],

--- a/lib/src/flow/bluetooth_tethering_flow.dart
+++ b/lib/src/flow/bluetooth_tethering_flow.dart
@@ -191,7 +191,6 @@ class _BluetoothTetheringFlowState extends State<BluetoothTetheringFlow> {
                               viam: widget.viewModel.viam,
                               robot: widget.viewModel.robot,
                             ),
-                            connectBluetoothDeviceRepository: widget.viewModel.connectBluetoothDeviceRepository,
                           ),
                         ),
                     ],

--- a/lib/src/flow/bluetooth_tethering_flow.dart
+++ b/lib/src/flow/bluetooth_tethering_flow.dart
@@ -12,7 +12,6 @@ class BluetoothTetheringFlow extends StatefulWidget {
     required String agentMinimumVersion,
     required BluetoothProvisioningFlowCopy copy,
     required onSuccess,
-    required handleAgentConfigured,
     required existingMachineExit,
     required nonexistentMachineExit,
     required agentMinimumVersionExit,
@@ -28,7 +27,6 @@ class BluetoothTetheringFlow extends StatefulWidget {
       agentMinimumVersion: agentMinimumVersion,
       copy: copy,
       onSuccess: onSuccess,
-      handleAgentConfigured: handleAgentConfigured,
       existingMachineExit: existingMachineExit,
       nonexistentMachineExit: nonexistentMachineExit,
       agentMinimumVersionExit: agentMinimumVersionExit,
@@ -187,7 +185,6 @@ class _BluetoothTetheringFlowState extends State<BluetoothTetheringFlow> {
                             successSubtitle: widget.viewModel.copy.checkingOnlineSuccessSubtitle,
                             successCta: widget.viewModel.copy.checkingOnlineSuccessCta,
                             handleSuccess: widget.viewModel.onSuccess,
-                            handleAgentConfigured: widget.viewModel.handleAgentConfigured,
                             handleError: _onPreviousPage,
                             checkingDeviceOnlineRepository: CheckingDeviceOnlineRepository(
                               device: widget.viewModel.device!,

--- a/lib/src/models/device_online_state.dart
+++ b/lib/src/models/device_online_state.dart
@@ -2,7 +2,6 @@ part of '../../viam_flutter_bluetooth_provisioning_widget.dart';
 
 enum DeviceOnlineState {
   checking,
-  agentConnected,
   success,
   errorConnecting,
 }

--- a/lib/src/repositories/checking_device_online_repository.dart
+++ b/lib/src/repositories/checking_device_online_repository.dart
@@ -40,21 +40,15 @@ class CheckingDeviceOnlineRepository {
         return;
       }
       _checkOnline();
-      _checkAgentStatus();
+      _readAgentErrors();
     });
   }
 
-  /// We want to read these sequentially for now, some errors observed trying to read ble characteristics in parallel
-  Future<void> _checkAgentStatus() async {
+  Future<void> _readAgentErrors() async {
     if (!device.isConnected) {
       return;
     }
 
-    await _readAgentErrors();
-    await _readAgentStatus();
-  }
-
-  Future<void> _readAgentErrors() async {
     try {
       if (_startingErrors == null) {
         _startingErrors = await device.readErrors();
@@ -71,17 +65,6 @@ class CheckingDeviceOnlineRepository {
       }
     } catch (e) {
       debugPrint('Error reading agent errors: $e');
-    }
-  }
-
-  Future<void> _readAgentStatus() async {
-    try {
-      final status = await device.readStatus();
-      if (status.isConnected && status.isConfigured && deviceOnlineState != DeviceOnlineState.success) {
-        deviceOnlineState = DeviceOnlineState.agentConnected; // timer still allowed to run for the online check
-      }
-    } on Exception catch (e) {
-      debugPrint('Error reading agent status: $e');
     }
   }
 

--- a/lib/src/view/check_connected_device_online_screen.dart
+++ b/lib/src/view/check_connected_device_online_screen.dart
@@ -13,6 +13,7 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
   @override
   void initState() {
     super.initState();
+    widget.viewModel.reconnect(); // reconnect to device if it was disconnected
     widget.viewModel.startChecking();
   }
 

--- a/lib/src/view/check_connected_device_online_screen.dart
+++ b/lib/src/view/check_connected_device_online_screen.dart
@@ -42,35 +42,6 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
     );
   }
 
-  Widget _buildAgentConnectedState(BuildContext context) {
-    return Center(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          CircularProgressIndicator(),
-          SizedBox(height: 24),
-          Text(
-            'Connected!',
-            style: Theme.of(context).textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
-          ),
-          SizedBox(height: 8),
-          Text(
-            '${widget.viewModel.robot.name} is connected and almost ready to use. You can leave this screen now and it will automatically come online in a few minutes.',
-            style: Theme.of(context).textTheme.bodyLarge,
-            textAlign: TextAlign.center,
-            maxLines: null,
-          ),
-          Spacer(),
-          FilledButton(
-            onPressed: widget.viewModel.handleAgentConfigured,
-            child: Text('Close'),
-          ),
-          SizedBox(height: 16),
-        ],
-      ),
-    );
-  }
-
   Widget _buildSuccessState(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.symmetric(horizontal: 16.0),
@@ -138,7 +109,6 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
           padding: const EdgeInsets.symmetric(horizontal: 16.0),
           child: switch (widget.viewModel.deviceOnlineState) {
             DeviceOnlineState.checking => _buildCheckingState(context),
-            DeviceOnlineState.agentConnected => _buildAgentConnectedState(context),
             DeviceOnlineState.success => _buildSuccessState(context),
             DeviceOnlineState.errorConnecting => _buildErrorConnectingState(context),
           },

--- a/lib/src/view/check_connected_device_online_screen.dart
+++ b/lib/src/view/check_connected_device_online_screen.dart
@@ -13,7 +13,6 @@ class _CheckConnectedDeviceOnlineScreenState extends State<CheckConnectedDeviceO
   @override
   void initState() {
     super.initState();
-    widget.viewModel.reconnect(); // reconnect to device if it was disconnected
     widget.viewModel.startChecking();
   }
 

--- a/lib/src/view_models/bluetooth_provisioning_flow_view_model.dart
+++ b/lib/src/view_models/bluetooth_provisioning_flow_view_model.dart
@@ -12,7 +12,6 @@ class BluetoothProvisioningFlowViewModel extends ChangeNotifier {
     this.agentMinimumVersion = '0.20.0',
     this.copy = const BluetoothProvisioningFlowCopy(),
     required this.onSuccess,
-    required this.handleAgentConfigured,
     required this.existingMachineExit,
     required this.nonexistentMachineExit,
     required this.agentMinimumVersionExit,
@@ -40,10 +39,6 @@ class BluetoothProvisioningFlowViewModel extends ChangeNotifier {
   }
 
   final VoidCallback onSuccess;
-
-  /// agent has indicated the machine is online and has machine credentials
-  /// though it may not be online in app.viam.com yet
-  final VoidCallback handleAgentConfigured;
 
   final VoidCallback existingMachineExit;
   final VoidCallback nonexistentMachineExit;

--- a/lib/src/view_models/check_connected_device_online_screen_view_model.dart
+++ b/lib/src/view_models/check_connected_device_online_screen_view_model.dart
@@ -18,7 +18,6 @@ class CheckConnectedDeviceOnlineScreenViewModel extends ChangeNotifier {
   }
 
   final CheckingDeviceOnlineRepository _checkingDeviceOnlineRepository;
-  final ConnectBluetoothDeviceRepository _connectBluetoothDeviceRepository;
   DeviceOnlineState _deviceOnlineState;
   StreamSubscription<DeviceOnlineState>? _deviceOnlineSubscription;
 
@@ -30,9 +29,7 @@ class CheckConnectedDeviceOnlineScreenViewModel extends ChangeNotifier {
     required this.successCta,
     required this.robot,
     required CheckingDeviceOnlineRepository checkingDeviceOnlineRepository,
-    required ConnectBluetoothDeviceRepository connectBluetoothDeviceRepository,
   })  : _checkingDeviceOnlineRepository = checkingDeviceOnlineRepository,
-        _connectBluetoothDeviceRepository = connectBluetoothDeviceRepository,
         _deviceOnlineState = checkingDeviceOnlineRepository.deviceOnlineState;
 
   @override
@@ -40,10 +37,6 @@ class CheckConnectedDeviceOnlineScreenViewModel extends ChangeNotifier {
     _deviceOnlineSubscription?.cancel();
     _checkingDeviceOnlineRepository.dispose();
     super.dispose();
-  }
-
-  Future<void> reconnect() async {
-    await _connectBluetoothDeviceRepository.reconnect();
   }
 
   void startChecking() {

--- a/lib/src/view_models/check_connected_device_online_screen_view_model.dart
+++ b/lib/src/view_models/check_connected_device_online_screen_view_model.dart
@@ -18,6 +18,7 @@ class CheckConnectedDeviceOnlineScreenViewModel extends ChangeNotifier {
   }
 
   final CheckingDeviceOnlineRepository _checkingDeviceOnlineRepository;
+  final ConnectBluetoothDeviceRepository _connectBluetoothDeviceRepository;
   DeviceOnlineState _deviceOnlineState;
   StreamSubscription<DeviceOnlineState>? _deviceOnlineSubscription;
 
@@ -29,7 +30,9 @@ class CheckConnectedDeviceOnlineScreenViewModel extends ChangeNotifier {
     required this.successCta,
     required this.robot,
     required CheckingDeviceOnlineRepository checkingDeviceOnlineRepository,
+    required ConnectBluetoothDeviceRepository connectBluetoothDeviceRepository,
   })  : _checkingDeviceOnlineRepository = checkingDeviceOnlineRepository,
+        _connectBluetoothDeviceRepository = connectBluetoothDeviceRepository,
         _deviceOnlineState = checkingDeviceOnlineRepository.deviceOnlineState;
 
   @override
@@ -37,6 +40,10 @@ class CheckConnectedDeviceOnlineScreenViewModel extends ChangeNotifier {
     _deviceOnlineSubscription?.cancel();
     _checkingDeviceOnlineRepository.dispose();
     super.dispose();
+  }
+
+  Future<void> reconnect() async {
+    await _connectBluetoothDeviceRepository.reconnect();
   }
 
   void startChecking() {

--- a/lib/src/view_models/check_connected_device_online_screen_view_model.dart
+++ b/lib/src/view_models/check_connected_device_online_screen_view_model.dart
@@ -2,11 +2,6 @@ part of '../../viam_flutter_bluetooth_provisioning_widget.dart';
 
 class CheckConnectedDeviceOnlineScreenViewModel extends ChangeNotifier {
   final VoidCallback handleSuccess;
-
-  /// agent has indicated the machine is online and has machine credentials
-  /// though it may not be online in app.viam.com yet
-  final VoidCallback handleAgentConfigured;
-
   final VoidCallback handleError;
   final Robot robot;
   final String successTitle;
@@ -28,7 +23,6 @@ class CheckConnectedDeviceOnlineScreenViewModel extends ChangeNotifier {
 
   CheckConnectedDeviceOnlineScreenViewModel({
     required this.handleSuccess,
-    required this.handleAgentConfigured,
     required this.handleError,
     required this.successTitle,
     required this.successSubtitle,


### PR DESCRIPTION
Relates to #53 and the change there. Right now with the addition of `exitProvisioning`, we won't have the viam bluetooth service to read from to determine if the agent has an internet connection (`status.isConnected`).

Agent can return to provisioning mode with readable errors, but we won't be able to read the status while trying to get an internet connection to make this determination early.