### PR TITLE
[APP-9144] Parse special agent versions for agent minimum check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -24,3 +24,6 @@ jobs:
 
       - name: Analyze project source
         run: dart analyze
+
+      - name: Run tests
+        run: flutter test

--- a/lib/src/repositories/connect_bluetooth_device_repository.dart
+++ b/lib/src/repositories/connect_bluetooth_device_repository.dart
@@ -106,8 +106,14 @@ class ConnectBluetoothDeviceRepository {
   }
 
   bool _isVersionLower(String currentVersion, String minimumVersion) {
-    List<int> current = currentVersion.split('.').map(int.parse).toList();
-    List<int> minimum = minimumVersion.split('.').map(int.parse).toList();
+    // Extract version numbers using regex (e.g., "0.20.4-release" -> "0.20.4")
+    final versionRegex = RegExp(r'^(\d+\.\d+\.\d+)');
+
+    String cleanCurrentVersion = versionRegex.firstMatch(currentVersion)?.group(1) ?? currentVersion;
+    String cleanMinimumVersion = versionRegex.firstMatch(minimumVersion)?.group(1) ?? minimumVersion;
+
+    List<int> current = cleanCurrentVersion.split('.').map(int.parse).toList();
+    List<int> minimum = cleanMinimumVersion.split('.').map(int.parse).toList();
 
     for (int i = 0; i < minimum.length; i++) {
       if (current[i] < minimum[i]) {

--- a/lib/src/repositories/connect_bluetooth_device_repository.dart
+++ b/lib/src/repositories/connect_bluetooth_device_repository.dart
@@ -98,31 +98,36 @@ class ConnectBluetoothDeviceRepository {
 
     try {
       final agentVersion = await _device!.readAgentVersion();
-      return _isVersionLower(agentVersion, minimumVersion);
+      return isVersionLower(currentVersionStr: agentVersion, minimumVersionStr: minimumVersion);
     } catch (e) {
       debugPrint('Error reading agent version: $e');
       return true;
     }
   }
 
-  bool _isVersionLower(String currentVersion, String minimumVersion) {
-    // Extract version numbers using regex (e.g., "0.20.4-release" -> "0.20.4")
+  bool isVersionLower({required String currentVersionStr, required String minimumVersionStr}) {
+    // extract version numbers using regex (e.g., "0.20.4-release" -> "0.20.4")
     final versionRegex = RegExp(r'^(\d+\.\d+\.\d+)');
+    String cleanCurrentVersion = versionRegex.firstMatch(currentVersionStr)?.group(1) ?? currentVersionStr;
+    String cleanMinimumVersion = versionRegex.firstMatch(minimumVersionStr)?.group(1) ?? minimumVersionStr;
+    List<int> currentIntList = cleanCurrentVersion.split('.').map(int.tryParse).whereType<int>().toList();
+    List<int> minimumIntList = cleanMinimumVersion.split('.').map(int.tryParse).whereType<int>().toList();
 
-    String cleanCurrentVersion = versionRegex.firstMatch(currentVersion)?.group(1) ?? currentVersion;
-    String cleanMinimumVersion = versionRegex.firstMatch(minimumVersion)?.group(1) ?? minimumVersion;
-
-    List<int> current = cleanCurrentVersion.split('.').map(int.parse).toList();
-    List<int> minimum = cleanMinimumVersion.split('.').map(int.parse).toList();
-
-    for (int i = 0; i < minimum.length; i++) {
-      if (current[i] < minimum[i]) {
-        return true; // Current version is lower
-      } else if (current[i] > minimum[i]) {
-        return false; // Current version is higher
-      }
+    if (currentIntList.isEmpty) {
+      return false; // no numbers, allow 'custom' pre-release versions to be higher than minimum
     }
-    return false; // Versions are equal
+    // not using the factory constructor because it can't parse 1.20 properly, so we'll convert that to 1.20.0
+    final currentVersion = Version(
+      currentIntList.elementAtOrNull(0) ?? 0,
+      currentIntList.elementAtOrNull(1) ?? 0,
+      currentIntList.elementAtOrNull(2) ?? 0,
+    );
+    final minimumVersion = Version(
+      minimumIntList.elementAtOrNull(0) ?? 0,
+      minimumIntList.elementAtOrNull(1) ?? 0,
+      minimumIntList.elementAtOrNull(2) ?? 0,
+    );
+    return currentVersion < minimumVersion;
   }
 
   Future<void> _fragmentOverride(Viam viam, String fragmentId, RobotPart robotPart, Robot robot) async {

--- a/lib/viam_flutter_bluetooth_provisioning_widget.dart
+++ b/lib/viam_flutter_bluetooth_provisioning_widget.dart
@@ -10,11 +10,13 @@ import 'package:viam_flutter_provisioning/viam_bluetooth_provisioning.dart';
 import 'package:flutter_platform_widgets/flutter_platform_widgets.dart';
 import 'package:viam_sdk/viam_sdk.dart' hide Permission;
 import 'package:viam_sdk/protos/app/app.dart';
+import 'package:pub_semver/pub_semver.dart';
 
 // export
 export 'package:viam_flutter_provisioning/viam_bluetooth_provisioning.dart';
 export 'package:viam_sdk/viam_sdk.dart' hide Permission;
 export 'package:viam_sdk/protos/app/app.dart';
+export 'package:pub_semver/pub_semver.dart';
 
 // flows
 part 'src/flow/bluetooth_provisioning_flow.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,6 +17,7 @@ dependencies:
   viam_flutter_provisioning: ^0.0.13
   flutter_platform_widgets: ^7.0.1
   provider: ^6.1.5
+  pub_semver: ^2.2.0
   
 dev_dependencies:
   flutter_test:

--- a/test/repositories/connect_bluetooth_device_repository_test.dart
+++ b/test/repositories/connect_bluetooth_device_repository_test.dart
@@ -35,13 +35,12 @@ void main() {
 
       test('should handle pre-release versions correctly', () {
         expect(repository.isVersionLower(currentVersionStr: '0.20.4-release', minimumVersionStr: '0.19.0'), false);
-        expect(
-            repository.isVersionLower(currentVersionStr: '0.20.4-release', minimumVersionStr: '0.20.4'), false); // we're calling it equal
-        expect(repository.isVersionLower(currentVersionStr: 'custom', minimumVersionStr: '0.20.4'), false);
+        expect(repository.isVersionLower(currentVersionStr: 'custom', minimumVersionStr: '0.20.4'), false); // custom beats any version
       });
 
       test('should return false when versions are equal', () {
         expect(repository.isVersionLower(currentVersionStr: '1.2.0', minimumVersionStr: '1.2.0'), false);
+        expect(repository.isVersionLower(currentVersionStr: '0.20.4-release', minimumVersionStr: '0.20.4'), false);
         expect(repository.isVersionLower(currentVersionStr: '0.20.4', minimumVersionStr: '0.20.4'), false);
       });
     });

--- a/test/repositories/connect_bluetooth_device_repository_test.dart
+++ b/test/repositories/connect_bluetooth_device_repository_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:viam_flutter_bluetooth_provisioning_widget/viam_flutter_bluetooth_provisioning_widget.dart';
+
+void main() {
+  group('ConnectBluetoothDeviceRepository', () {
+    late ConnectBluetoothDeviceRepository repository;
+
+    setUp(() {
+      repository = ConnectBluetoothDeviceRepository();
+    });
+
+    tearDown(() {
+      repository.dispose();
+    });
+
+    group('isVersionLower', () {
+      test('should return false when current version is higher than minimum', () {
+        expect(repository.isVersionLower(currentVersionStr: '1.2.0', minimumVersionStr: '1.1.0'), false);
+        expect(repository.isVersionLower(currentVersionStr: '2.0.0', minimumVersionStr: '1.9.9'), false);
+        expect(repository.isVersionLower(currentVersionStr: '0.20.4', minimumVersionStr: '0.19.0'), false);
+        expect(repository.isVersionLower(currentVersionStr: '0.0.2', minimumVersionStr: '0.0.1'), false);
+        expect(repository.isVersionLower(currentVersionStr: '1.20', minimumVersionStr: '1.18.5'), false);
+        expect(repository.isVersionLower(currentVersionStr: '0.2', minimumVersionStr: '0.1'), false);
+      });
+
+      test('should return true when current version is lower than minimum', () {
+        expect(repository.isVersionLower(currentVersionStr: '1.1.0', minimumVersionStr: '1.2.0'), true);
+        expect(repository.isVersionLower(currentVersionStr: '1.9.9', minimumVersionStr: '2.0.0'), true);
+        expect(repository.isVersionLower(currentVersionStr: '0.19.0', minimumVersionStr: '0.20.4'), true);
+        expect(repository.isVersionLower(currentVersionStr: '0.0.1', minimumVersionStr: '0.0.2'), true);
+        expect(repository.isVersionLower(currentVersionStr: '1.18.5', minimumVersionStr: '1.20'), true);
+        expect(repository.isVersionLower(currentVersionStr: '0.1', minimumVersionStr: '0.2'), true);
+      });
+
+      test('should handle pre-release versions correctly', () {
+        expect(repository.isVersionLower(currentVersionStr: '0.20.4-release', minimumVersionStr: '0.19.0'), false);
+        expect(
+            repository.isVersionLower(currentVersionStr: '0.20.4-release', minimumVersionStr: '0.20.4'), false); // we're calling it equal
+        expect(repository.isVersionLower(currentVersionStr: 'custom', minimumVersionStr: '0.20.4'), false);
+      });
+
+      test('should return false when versions are equal', () {
+        expect(repository.isVersionLower(currentVersionStr: '1.2.0', minimumVersionStr: '1.2.0'), false);
+        expect(repository.isVersionLower(currentVersionStr: '0.20.4', minimumVersionStr: '0.20.4'), false);
+      });
+    });
+  });
+}

--- a/test/viam_flutter_provisioning_widget_test.dart
+++ b/test/viam_flutter_provisioning_widget_test.dart
@@ -1,7 +1,0 @@
-// import 'package:flutter_test/flutter_test.dart';
-
-// import 'package:viam_flutter_provisioning_widget/viam_flutter_provisioning_widget.dart';
-
-// void main() {
-//   test('', () {});
-// }


### PR DESCRIPTION
Can't do any pre-release testing w/ agent versions like `0.20.4-release` b/c of the parsing logic here:
```
I/flutter ( 4214): Error reading agent version: FormatException: Invalid radix-10 number (at character 1)
I/flutter ( 4214): custom
I/flutter ( 4214): ^
I/flutter ( 4214): 
```
Resolving the above to `0.20.4` I think makes since so we can at least proceed and treat it like it's semantic version

also any `custom` named version should bypass any version, if someone is using a pre-release or custom version that is not who we're trying to catch with this