### PR TITLE
get Navigator earlier in _goToBluetoothTetheringFlow

### DIFF
--- a/example/lib/reconnect_machines_screen.dart
+++ b/example/lib/reconnect_machines_screen.dart
@@ -132,35 +132,34 @@ class _ReconnectRobotsScreenState extends State<ReconnectRobotsScreen> {
   }
 
   void _goToBluetoothTetheringFlow(BuildContext context, Viam viam, Robot robot) async {
+    final nav = Navigator.of(context);
     final mainPart = (await viam.appClient.listRobotParts(robot.id)).firstWhere((element) => element.mainPart);
-    if (context.mounted) {
-      Navigator.of(context).push(MaterialPageRoute(
-        builder: (context) => BluetoothTetheringFlow(
-          viam: viam,
-          robot: robot,
-          isNewMachine: false,
-          mainRobotPart: mainPart,
-          psk: Consts.psk,
-          fragmentId: null,
-          agentMinimumVersion: '0.20.0',
-          copy: BluetoothProvisioningFlowCopy(
-            checkingOnlineSuccessSubtitle: '${robot.name} is connected and ready to use.',
-          ),
-          onSuccess: () {
-            Navigator.of(context).pop();
-          },
-          existingMachineExit: () {
-            Navigator.of(context).pop();
-          },
-          nonexistentMachineExit: () {
-            Navigator.of(context).pop();
-          },
-          agentMinimumVersionExit: () {
-            Navigator.of(context).pop();
-          },
+    nav.push(MaterialPageRoute(
+      builder: (context) => BluetoothTetheringFlow(
+        viam: viam,
+        robot: robot,
+        isNewMachine: false,
+        mainRobotPart: mainPart,
+        psk: Consts.psk,
+        fragmentId: null,
+        agentMinimumVersion: '0.20.0',
+        copy: BluetoothProvisioningFlowCopy(
+          checkingOnlineSuccessSubtitle: '${robot.name} is connected and ready to use.',
         ),
-      ));
-    }
+        onSuccess: () {
+          Navigator.of(context).pop();
+        },
+        existingMachineExit: () {
+          Navigator.of(context).pop();
+        },
+        nonexistentMachineExit: () {
+          Navigator.of(context).pop();
+        },
+        agentMinimumVersionExit: () {
+          Navigator.of(context).pop();
+        },
+      ),
+    ));
   }
 
   void _showActionDialog(BuildContext context, Robot robot) {


### PR DESCRIPTION
## What changed
- get the navigator at the top of this function instead of doing a context.mounted check after the async gap
## Why
For android users, the tether button sometimes didn't work; the reason was `context.mounted = false`