### PR TITLE
CONSULT-1574 Remove default copy around flashing blue

### DIFF
--- a/lib/src/models/bluetooth_provisioning_flow_copy.dart
+++ b/lib/src/models/bluetooth_provisioning_flow_copy.dart
@@ -8,7 +8,7 @@ class BluetoothProvisioningFlowCopy {
     this.introScreenCtaText = 'Get started',
     // Intro screen tow
     this.introScreenTwoTurnOnTitle = 'Turn on your machine',
-    this.introScreenTwoTurnOnSubtitle = 'Plug in the machine and power it on. The light should be slowly flashing blue.',
+    this.introScreenTwoTurnOnSubtitle = 'Plug in the machine and power it on.',
     this.introScreenTwoBluetoothTitle = 'Pair via Bluetooth',
     // TODO: add markdown package so we can have italicized text
     this.introScreenTwoBluetoothSubtitle = 'Open your phone’s settings app and go to Settings > Bluetooth. Make sure it is set to “ON.”',


### PR DESCRIPTION
https://viam.atlassian.net/browse/CONSULT-1574

Relates to the above ticket, the default copy in the widget shouldn't mention this either this is not a universal assumption we can make