### PR TITLE
add dotenv support for secrets

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,1 @@
+secrets.env

--- a/example/README.md
+++ b/example/README.md
@@ -16,6 +16,19 @@ class Consts {
 }
 ```
 
+You can alternatively use a secrets.env file like:
+
+```sh
+VIAM_API_KEY_ID=uuid
+VIAM_API_KEY=secret
+VIAM_ORG_ID=uuid
+# VIAM_PSK=xxx # optional
+```
+
+If you don't use secrets.env, you'll still need to `touch secrets.env` once, or your builds will fail with:
+
+> No file or variants found for asset: secrets.env.
+
 2. **Run the app** on a physical device:
 
 ```bash

--- a/example/lib/consts.dart
+++ b/example/lib/consts.dart
@@ -1,12 +1,22 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
 class Consts {
   // TODO: Populate with your own api Keys.
-  static const String apiKeyId = '';
-  static const String apiKey = '';
+  static String apiKeyId = '';
+  static String apiKey = '';
 
-  static const String organizationId = '';
+  static String organizationId = '';
 
   /// defaults to 'viamsetup', but if your viam-agent network configuration: https://docs.viam.com/manage/reference/viam-agent/#network_configuration
   /// has a value set for hotspot_password that will be used instead.
   /// this pre-shared key is prepended to bluetooth characteristic writes and decoded on the viam-agent side.
-  static const String psk = 'viamsetup';
+  static String psk = 'viamsetup';
+
+  /// override static credentials with dotenv, if present
+  static void reload() {
+    apiKeyId = dotenv.env['VIAM_API_KEY_ID'] ?? apiKeyId;
+    apiKey = dotenv.env['VIAM_API_KEY'] ?? apiKey;
+    organizationId = dotenv.env['VIAM_ORG_ID'] ?? organizationId;
+    psk = dotenv.env['VIAM_PSK'] ?? psk;
+  }
 }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,9 +1,12 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import 'consts.dart';
 import 'start_screen.dart';
 
-void main() {
+Future main() async {
+  await dotenv.load(fileName: 'secrets.env');
+  Consts.reload();
   runApp(const MyApp());
 }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,7 +5,7 @@ import 'consts.dart';
 import 'start_screen.dart';
 
 Future main() async {
-  await dotenv.load(fileName: 'secrets.env');
+  await dotenv.load(fileName: 'secrets.env', isOptional: true);
   Consts.reload();
   runApp(const MyApp());
 }

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   provider: ^6.1.5
+  flutter_dotenv: ^6.0.0
   viam_flutter_bluetooth_provisioning_widget:
     path: ../
 
@@ -32,3 +33,5 @@ flutter:
   # included with your application, so that you can use the icons in
   # the material Icons class.
   uses-material-design: true
+  assets:
+  - secrets.env


### PR DESCRIPTION
## What changed
- allow people to put secrets in a .env file as an alternative to editing consts.dart (see readme for example)
## Why
I live in fear of accidentally checking in my secrets file.

Note: this requires `touch secrets.env` when you first build, or else the build will fail with:
> No file or variants found for asset: secrets.env.

^ if this is annoying to people who work in this repo full time, I'm okay closing this PR.