### PR TITLE
fix confusing 'pair' copy

### DIFF
--- a/lib/src/models/bluetooth_provisioning_flow_copy.dart
+++ b/lib/src/models/bluetooth_provisioning_flow_copy.dart
@@ -9,7 +9,7 @@ class BluetoothProvisioningFlowCopy {
     // Intro screen tow
     this.introScreenTwoTurnOnTitle = 'Turn on your machine',
     this.introScreenTwoTurnOnSubtitle = 'Plug in the machine and power it on.',
-    this.introScreenTwoBluetoothTitle = 'Pair via Bluetooth',
+    this.introScreenTwoBluetoothTitle = 'Enable Bluetooth on your phone',
     // TODO: add markdown package so we can have italicized text
     this.introScreenTwoBluetoothSubtitle = 'Open your phone’s settings app and go to Settings > Bluetooth. Make sure it is set to “ON.”',
     // Bluetooth scanning


### PR DESCRIPTION
## What changed
- 'pair via bluetooth' -> 'enable bluetooth' (so that the heading matches its subtitle)
## Why
Avoid confusion as we do more user testing.