### PR TITLE
[CONSULT-1699] Set fragmentId as object

### DIFF
--- a/lib/src/repositories/connect_bluetooth_device_repository.dart
+++ b/lib/src/repositories/connect_bluetooth_device_repository.dart
@@ -132,7 +132,11 @@ class ConnectBluetoothDeviceRepository {
 
   Future<void> _fragmentOverride(Viam viam, String fragmentId, RobotPart robotPart, Robot robot) async {
     Map<String, dynamic> config = {
-      "fragments": [fragmentId]
+      "fragments": [
+        {
+          "id": fragmentId,
+        }
+      ]
     };
     await viam.appClient.updateRobotPart(robotPart.id, robot.name, config);
   }


### PR DESCRIPTION
The fleet team is migrating the config so the fragmentId is stored as an object rather than a string. This PR changes the fragment override so it uploads the id as an object rather than a string.

**Links**
- [CONSULT-1664](https://viam.atlassian.net/browse/CONSULT-1664)
- [APP-8896](https://viam.atlassian.net/browse/APP-8896)

**Screenshot**
The config updated correctly when I created a new machine in the example app

<img width="953" height="335" alt="Screenshot 2025-09-19 at 1 13 24 PM" src="https://github.com/user-attachments/assets/ca5fdec5-b62a-46ad-91bc-be3758c5a711" />

[CONSULT-1664]: https://viam.atlassian.net/browse/CONSULT-1664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APP-8896]: https://viam.atlassian.net/browse/APP-8896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ