### PR TITLE
APP-9402 Conditional re-connect before unlock

### DIFF
--- a/lib/src/view_models/bluetooth_provisioning_flow_view_model.dart
+++ b/lib/src/view_models/bluetooth_provisioning_flow_view_model.dart
@@ -137,10 +137,17 @@ class BluetoothProvisioningFlowViewModel extends ChangeNotifier {
 
   Future<bool> unlockBluetoothPairing(BuildContext context) async {
     try {
+      if (device == null) {
+        throw Exception('Device is not connected');
+      }
+
       isLoading = true;
-      await device?.unlockPairing(psk: _psk);
+      if (!device!.isConnected) {
+        await device!.connect();
+      }
+      await device!.unlockPairing(psk: _psk);
       debugPrint('unlocked pairing');
-      await device?.disconnect();
+      await device!.disconnect();
       debugPrint('disconnected from device');
       return true;
     } catch (e) {


### PR DESCRIPTION
https://viam.atlassian.net/browse/APP-9402

Solves the bug in the ticket of unlocking pairing ~> disconnecting and then tapping back and trying to proceed again. I thought about changing the navigation to pop them back to the scanning screen to re-connect, but it's even simpler to re-connect the device we already have.