### PR TITLE
Add Dependabot

### DIFF
--- a/.github/workflows/dependabot.yaml
+++ b/.github/workflows/dependabot.yaml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pub"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
adds a dependabot configuration file to the repo. will check for pub and github action dependency updates daily, and auto create a PR for updating.

https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide