### PR TITLE
Bump viam-sdk minimum to 0.10.0

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
 
   permission_handler: ^12.0.0+1
-  viam_sdk: ^0.6.4
+  viam_sdk: ^0.10.0
   collection: ^1.18.0
   viam_flutter_provisioning: ^0.0.13
   flutter_platform_widgets: ^7.0.1


### PR DESCRIPTION
Bumping to match hotspot: https://github.com/viamrobotics/viam_flutter_hotspot_provisioning_widget/blob/ea60a5fe6caea85ef81bf664aada42cbcf5331f2/pubspec.yaml#L15