### PR TITLE
[no-ticket] helpful debug prints for device connection states

### DIFF
--- a/lib/src/repositories/checking_device_online_repository.dart
+++ b/lib/src/repositories/checking_device_online_repository.dart
@@ -49,6 +49,8 @@ class CheckingDeviceOnlineRepository {
           deviceOnlineState = DeviceOnlineState.errorConnecting;
           _errorMessageController.add(error);
         }
+      } else {
+        debugPrint('checking device online: device not connected');
       }
     });
   }

--- a/lib/src/repositories/connect_bluetooth_device_repository.dart
+++ b/lib/src/repositories/connect_bluetooth_device_repository.dart
@@ -38,6 +38,8 @@ class ConnectBluetoothDeviceRepository {
     if (_connectedDevice?.isConnected == false && _connectedDevice != null) {
       await connect(_connectedDevice!);
       debugPrint('reconnected to device');
+    } else if (_connectedDevice?.isConnected == true) {
+      debugPrint('reconnect: device already connected');
     }
   }
 


### PR DESCRIPTION
Helps clarify when we try to reconnect + when we get disconnected checking online at the end of the regular provisioning flow. Good for debugging and will help debug w/ some proposed changes to the agent (keeping ble service advertising)

```
flutter: created robot: ble-provisioning-843
flutter: connected to device on attempt 1
flutter: reconnect: device already connected
flutter: Error reading agent errors: Exception: bleService not found after 2 attempts
flutter: Error reading agent errors: Exception: bleService not found after 2 attempts
flutter: Error reading agent errors: Exception: bleService not found after 2 attempts
flutter: Error reading agent errors: Exception: bleService not found after 2 attempts
flutter: checking device online: device not connected
flutter: checking device online: device not connected
flutter: checking device online: device not connected
flutter: checking device online: device not connected
```